### PR TITLE
Cleanup proc notebooks and add more events.

### DIFF
--- a/notebooks/ModificationProcs.ipynb
+++ b/notebooks/ModificationProcs.ipynb
@@ -41,9 +41,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 598,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": []
+    }
+   ],
    "source": [
     "import glob\n",
     "\n",
@@ -64,20 +66,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 710,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "262911"
-      ]
-     },
-     "execution_count": 710,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "all_files = glob.glob(\"../roll_data/*-modproc.csv\")\n",
     "\n",
@@ -90,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 711,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,59 +208,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "#Shows Peanut Mister Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"NoHaunt\", \"YesHaunt\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Mild Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"NoHaunt\", \"YesHaunt\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Birds Ambush Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"NoHaunt\", \"YesHaunt\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Echo Chamber Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"NoHaunt\", \"YesHaunt\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Taste the Infinite (Pitcher) Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"NoHaunt\", \"YesHaunt\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Electric Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"NoHaunt\", \"YesHaunt\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Base Instincts Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"NoHaunt\", \"YesHaunt\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Smithy Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\",\"Bucket\", \"NoBucket\", \"NoHaunt\", \"YesHaunt\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 801,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "25374"
-      ]
-     },
-     "execution_count": 801,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "dfc = df.copy()\n",
     "for exclude_mod in []:\n",
@@ -279,29 +220,39 @@
     "    dfc = dfc[~dfc[\"batting_team_mods\"].astype(str).str.contains(exclude_mod)]\n",
     "    dfc = dfc[~dfc[\"fielder_mods\"].astype(str).str.contains(exclude_mod)]\n",
     "\n",
-    "#Shows Haunted Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
+    "len(dfc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mister_events = (\"cure\", \"NoCure\")\n",
+    "mild_events = (\"Mild\", \"NoMild\")\n",
+    "birds_ambush_events = (\"Ambushed\", \"NoBush\")\n",
+    "echo_chamber_events = (\"Copy\", \"nocopy\")\n",
+    "taste_infinite_events = (\"shelled2\", \"no shell2\")\n",
+    "electric_events = (\"Zap\", \"NoZap\")\n",
+    "base_instinct_events = (\"Walk\", \"Balk\", \"Second\", \"Third\")\n",
+    "smithy_events = (\"Fix\", \"NoFix\")\n",
+    "haunted_events = (\"NoHaunt\", \"YesHaunt\")\n",
+    "grind_rail_events = (\"Grind\", \"NoGrind\")\n",
+    "taste_infinite_batter_events = (\"shelled1\", \"no shell1\")\n",
+    "debt_events = (\"Bonk\", \"No Bonk\")\n",
+    "big_buckets_events = (\"Bucket\", \"NoBucket\")\n",
+    "acidic_events = (\"Acidic Pitch\", \"Not Acidic Pitch\")\n",
+    "double_strike_events = (\"Double Strike\", \"Single Strike\")\n",
+    "hotel_motel_events = (\"Hotel\", \"Notel\")\n",
     "\n",
-    "#Shows Grind Rail Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"NoHaunt\", \"YesHaunt\"]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
+    "include_events = double_strike_events\n",
     "\n",
-    "#Shows Taste the Infinite (Batter) Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\", \"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"NoHaunt\", \"YesHaunt\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
+    "dfc = dfc[dfc[\"event_type\"].astype(str).isin(include_events)]\n",
     "\n",
-    "#Shows Debt Proc\n",
-    "#for exclude_event in [\"NoHaunt\", \"Fix\", \"NoFix\", \"YesHaunt\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Charm Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"NoHaunt\", \"YesHaunt\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"Bucket\", \"NoBucket\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Big Buckets Proc\n",
-    "#for exclude_event in [\"Bonk\", \"No Bonk\",\"Fix\", \"NoFix\", \"Ambushed\", \"NoBush\", \"Charmed\", \"NoCharm\", \"Zap\", \"NoZap\", \"Mild\", \"NoMild\", \"Walk\", \"Balk\", \"Second\", \"Third\", \"NoHaunt\", \"YesHaunt\", \"shelled1\", \"no shell1\", \"shelled2\", \"no shell2\", \"Copy\", \"nocopy\", \"cure\", \"NoCure\", \"Grind\", \"NoGrind\",]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
+    "if \"Hotel\" in include_events:\n",
+    "    # These rolls are not in the right place currently\n",
+    "    dfc = dfc[~dfc[\"inning\"] == -1]\n",
     "\n",
     "len(dfc)"
    ]
@@ -564,7 +515,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.5 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -578,7 +529,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.0"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/WeatherProcs.ipynb
+++ b/notebooks/WeatherProcs.ipynb
@@ -60,33 +60,18 @@
     "    dfc = dfc[~dfc[\"batting_team_mods\"].astype(str).str.contains(exclude_mod)]\n",
     "    dfc = dfc[~dfc[\"fielder_mods\"].astype(str).str.contains(exclude_mod)]\n",
     "\n",
-    "#Shows Coffee Weather Proc\n",
-    "#for exclude_event in [\"Refill\", \"NoRefill\", \"Swept\", \"NoSweep\", \"Shuffle\", \"NoShuffle\", \"Drain\", \"Siphon\", \"Swap\", \"NoSwap\", \"Allergy\", \"NoAllergy\"]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
+    "coffee_events = (\"Bean\", \"NoBean\")\n",
+    "coffee2_events = (\"Refill\", \"NoRefill\")\n",
+    "flooding_events = (\"Swept\", \"NoSweep\")\n",
+    "reverb_events = (\"Shuffle\", \"NoShuffle\")\n",
+    "bloodrain_events = (\"Drain\", \"Siphon\") # NOTE: FAILURES ARE SIPHON EVENTS ONLY\n",
+    "feedback_events = (\"Swap\", \"NoSwap\")\n",
+    "peanut_events = (\"Allergy\", \"NoAllergy\")\n",
+    "salmon_events = (\"Salmon\", \"NoSalmon\")\n",
     "\n",
-    "#Shows Coffee 2 Weather Proc\n",
-    "#for exclude_event in [\"Bean\", \"NoBean\", \"Swept\", \"NoSweep\", \"Shuffle\", \"NoShuffle\", \"Drain\", \"Siphon\", \"Swap\", \"NoSwap\", \"Allergy\", \"NoAllergy\"]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
+    "include_events = salmon_events\n",
     "\n",
-    "#Shows Flooding Weather Proc\n",
-    "#for exclude_event in [\"Refill\", \"NoRefill\", \"Bean\", \"NoBean\", \"Shuffle\", \"NoShuffle\", \"Drain\", \"Siphon\", \"Swap\", \"NoSwap\", \"Allergy\", \"NoAllergy\"]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Reverb Weather Proc\n",
-    "#for exclude_event in [\"Refill\", \"NoRefill\", \"Swept\", \"NoSweep\", \"Bean\", \"NoBean\", \"Drain\", \"Siphon\", \"Swap\", \"NoSwap\", \"Allergy\", \"NoAllergy\"]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Blooddrain Weather Proc - NOTE: FAILURES ARE SIPHON EVENTS ONLY\n",
-    "for exclude_event in [\"Refill\", \"NoRefill\", \"Swept\", \"NoSweep\", \"Bean\", \"NoBean\", \"Swap\", \"NoSwap\", \"Shuffle\", \"NoShuffle\", \"Allergy\", \"NoAllergy\"]:\n",
-    "    dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Feedback Weather Proc\n",
-    "#for exclude_event in [\"Refill\", \"NoRefill\", \"Swept\", \"NoSweep\", \"Shuffle\", \"NoShuffle\", \"Drain\", \"Siphon\", \"Bean\", \"NoBean\", \"Allergy\", \"NoAllergy\"]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n",
-    "\n",
-    "#Shows Peanut Weather Proc\n",
-    "#for exclude_event in [\"Refill\", \"NoRefill\", \"Swept\", \"NoSweep\", \"Swap\", \"NoSwap\", \"Shuffle\", \"NoShuffle\", \"Drain\", \"Siphon\", \"Bean\", \"NoBean\"]:\n",
-    "    #dfc = dfc[~dfc[\"event_type\"].astype(str).str.contains(exclude_event)]\n"
+    "dfc = dfc[dfc[\"event_type\"].astype(str).isin(include_events)]"
    ]
   },
   {
@@ -1281,7 +1266,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.5 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1295,7 +1280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.0"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Make event filtering in the notebooks based on inclusion instead of exclusion, so it's more straightforward and maintainable. Move them into notebooks dir.
Add logging for salmon weather, acidic pitches, double strikes, and hotel motel.